### PR TITLE
Rename Properties::method merge() to Properties::mergeProperties() to…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ php:
   - 7.0
   - 5.6
   - 5.5
-  - 5.4
 
 matrix:
   allow_failures:
     - php: 7.0
 
 before_install:
-  - pecl install pthreads-2.0.10
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.0" ]]; then pecl install pthreads-2.0.10; fi
+  - if [[ "$TRAVIS_PHP_VERSION" = "7.0" ]] || [[ "$TRAVIS_PHP_VERSION" > "7.0" ]]; then pecl install pthreads-3.1.6; fi
   - pecl install xdebug
   - phpenv rehash
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 2.1.1
+
+## Bugfixes
+
+* Rename Properties::method merge() to Properties::mergeProperties() to avoid incompatibilities with AbstractCollection::merge()
+
+## Features
+
+* Switch to latest appserver-io/lang branch ~3.0
+
 # Version 2.1.0
 
 ## Bugfixes

--- a/src/AppserverIo/Properties/Properties.php
+++ b/src/AppserverIo/Properties/Properties.php
@@ -278,7 +278,7 @@ class Properties extends HashMap implements PropertiesInterface
      *
      * @return void
      */
-    public function merge(PropertiesInterface $properties, $override = false)
+    public function mergeProperties(PropertiesInterface $properties, $override = false)
     {
         // iterate over the keys of the passed properties and add thm, or replace existing ones
         foreach ($properties as $key => $value) {

--- a/src/AppserverIo/Properties/PropertiesInterface.php
+++ b/src/AppserverIo/Properties/PropertiesInterface.php
@@ -87,4 +87,15 @@ interface PropertiesInterface extends MapInterface
      * @return array The keys as array values
      */
     public function getKeys();
+
+    /**
+     * Merges the passed properties into the actual instance. If override
+     * flag is set to TRUE, existing properties will be overwritten.
+     *
+     * @param \AppserverIo\Properties\PropertiesInterface $properties The properties to merge
+     * @param boolean                                     $override   TRUE if existing properties have to be overwritten, else FALSE
+     *
+     * @return void
+     */
+    public function mergeProperties(PropertiesInterface $properties, $override = false);
 }

--- a/tests/AppserverIo/Properties/PropertiesUtilTest.php
+++ b/tests/AppserverIo/Properties/PropertiesUtilTest.php
@@ -58,7 +58,7 @@ class PropertiesUtilTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testMergeWithSameKeyNotOverride()
+    public function testMergePropertiesWithSameKeyNotOverride()
     {
 
         // initialize the properties
@@ -72,7 +72,7 @@ class PropertiesUtilTest extends \PHPUnit_Framework_TestCase
         $propertiesToMerge->setProperty('foobar', 'something');
 
         // merge the properties
-        $properties->merge($propertiesToMerge);
+        $properties->mergeProperties($propertiesToMerge);
 
         // assert that the results are as expected
         $this->assertSame('${bar}', $properties->getProperty('foo'));
@@ -86,7 +86,7 @@ class PropertiesUtilTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testMergeWithSameKeyAndOverride()
+    public function testMergePropertiesWithSameKeyAndOverride()
     {
 
         // initialize the properties
@@ -98,7 +98,7 @@ class PropertiesUtilTest extends \PHPUnit_Framework_TestCase
         $propertiesToMerge->setProperty('foo', 'bar');
 
         // merge the properties
-        $properties->merge($propertiesToMerge, true);
+        $properties->mergeProperties($propertiesToMerge, true);
 
         // assert that the results are as expected
         $this->assertSame('bar', $properties->getProperty('foo'));


### PR DESCRIPTION
… avoid incompatibilities with AbstractCollection::merge()